### PR TITLE
修复 RISC-V 构建错误

### DIFF
--- a/user/init/GNUmakefile
+++ b/user/init/GNUmakefile
@@ -7,8 +7,10 @@ endif
 export RUSTFLAGS := -C target-feature=+crt-static -C link-arg=-static \
 					-L$(PROJECT_ROOT)/./user/init/target/$(TARGET) -C linker=$(ARCH)-linux-gnu-ld
 
+TARGET_DIR := $(PROJECT_ROOT)/user/init/target/$(TARGET)
 all:
-	ln -sf $(PROJECT_ROOT)/./libgcc_$(ARCH).a $(PROJECT_ROOT)/./user/init/target/$(TARGET)/libgcc.a
+	mkdir -p $(TARGET_DIR)
+	ln -sf $(PROJECT_ROOT)/libgcc_$(ARCH).a $(TARGET_DIR)/libgcc.a
 	cargo build --target=$(TARGET)
 	sudo rm -rf $(shell pwd)/../rootfs-$(ARCH)/sbin/init
 	sudo cp -r target/$(TARGET)/debug/init $(shell pwd)/../rootfs-$(ARCH)/sbin/init


### PR DESCRIPTION
在 user/init/GNUmakefile 中新增目录创建逻辑，避免构建时目录不存在导致 ln 报错。

